### PR TITLE
Fix: Remove console log in comments component

### DIFF
--- a/src/components/comments.tsx
+++ b/src/components/comments.tsx
@@ -173,7 +173,6 @@ export const Comments: React.FC<CommentProps> = ({url}) => {
       })
 
       const json = await response.json()
-      console.log(json)
       setComments(json)
     }
     fetchComments()


### PR DESCRIPTION
Hi there @jeffrafter 

I am having a look at the way you implemented comments to do the same on my site and saw a `console.log()` you left on the request. 

Hope this helps you!